### PR TITLE
Added kwargs type suggestion support.

### DIFF
--- a/izulu/root.py
+++ b/izulu/root.py
@@ -66,7 +66,7 @@ def factory(
         otherwise func will be invoced without argument
     """
 
-    target = factory if self else (lambda _: default_factory())
+    target = default_factory if self else (lambda _: default_factory())
     return functools.cached_property(target)
 
 

--- a/izulu/root.py
+++ b/izulu/root.py
@@ -39,7 +39,7 @@ FactoryReturnType = t.TypeVar("FactoryReturnType")
 
 @t.overload
 def factory(
-    func: t.Callable[[], FactoryReturnType],
+    factory: t.Callable[[], FactoryReturnType],
     *,
     self: t.Literal[False] = False,
 ) -> FactoryReturnType: ...
@@ -47,14 +47,14 @@ def factory(
 
 @t.overload
 def factory(
-    func: t.Callable[[Error], FactoryReturnType],
+    factory: t.Callable[[Error], FactoryReturnType],
     *,
     self: t.Literal[True],
 ) -> FactoryReturnType: ...
 
 
 def factory(
-    func: t.Callable[..., t.Any],
+    factory: t.Callable[..., t.Any],
     *,
     self: bool = False,
 ) -> t.Any:
@@ -66,11 +66,7 @@ def factory(
         otherwise func will be invoced without argument
     """
 
-    target = func if self else (lambda obj: func())
-    target = t.cast(
-        t.Callable[[t.Any], t.Any],
-        target,
-    )  # type: ignore [assignment]
+    target = factory if self else (lambda _: factory())
     return functools.cached_property(target)
 
 
@@ -89,6 +85,13 @@ class Features(enum.Flag):
     )
 
 
+@t_ext.dataclass_transform(
+    eq_default=False,
+    order_default=False,
+    kw_only_default=True,
+    frozen_default=False,
+    field_specifiers=(factory,),
+)
 class Error(Exception):
     """Base class for your exception trees
 
@@ -265,14 +268,3 @@ class Error(Exception):
             for field, const in self.__cls_store.consts.items():
                 d.setdefault(field, const)
         return d
-
-
-@t_ext.dataclass_transform(
-    eq_default=False,
-    order_default=False,
-    kw_only_default=True,
-    frozen_default=False,
-    field_specifiers=(factory,),
-)
-class DataclassHintedError(Error):
-    pass

--- a/izulu/root.py
+++ b/izulu/root.py
@@ -39,7 +39,7 @@ FactoryReturnType = t.TypeVar("FactoryReturnType")
 
 @t.overload
 def factory(
-    factory: t.Callable[[], FactoryReturnType],
+    default_factory: t.Callable[[], FactoryReturnType],
     *,
     self: t.Literal[False] = False,
 ) -> FactoryReturnType: ...
@@ -47,14 +47,14 @@ def factory(
 
 @t.overload
 def factory(
-    factory: t.Callable[[Error], FactoryReturnType],
+    default_factory: t.Callable[[Error], FactoryReturnType],
     *,
     self: t.Literal[True],
 ) -> FactoryReturnType: ...
 
 
 def factory(
-    factory: t.Callable[..., t.Any],
+    default_factory: t.Callable[..., t.Any],
     *,
     self: bool = False,
 ) -> t.Any:
@@ -66,7 +66,7 @@ def factory(
         otherwise func will be invoced without argument
     """
 
-    target = factory if self else (lambda _: factory())
+    target = factory if self else (lambda _: default_factory())
     return functools.cached_property(target)
 
 


### PR DESCRIPTION
This PR adds support for static analyzers to validate inputs. Using **kwargs for type annotations is ambiguous and can be difficult to use, as users must remember all the arguments required for an exception.

This PR add support for static analyzers and type checkers for `Exception` constructor.

Here are some screenshots:

![image](https://github.com/user-attachments/assets/14cc1ef5-1af7-4391-a726-09798f858084)

![image](https://github.com/user-attachments/assets/3a197556-d3a9-413b-8c2d-fb1baacfaf47)

![image](https://github.com/user-attachments/assets/56cd73b1-419a-4caf-bfb4-88d636e94aae)

![image](https://github.com/user-attachments/assets/a06a7be3-8756-4310-bcc1-cb22dec8beb3)

Here are some caveats:

It would be better if we could modify the `factory` function to accept only keyword arguments. As a `field_specifier`, it works only when `factory` is specified via a kwarg. You can read more about this in the [Field Specifier Parameters](https://peps.python.org/pep-0681) section of PEP 681.

Here's how it looks if factory is given as a positional argument: ![image](https://github.com/user-attachments/assets/4eb0b74b-814c-416e-bbd7-5008a5fad740).