### PR TITLE
Make some typing improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ classifiers = [
   "Typing :: Typed",
 ]
 keywords = ["error", "exception", "oop", "izulu"]
+dependencies = [
+    "typing-extensions>=4.5.0",
+]
 
 [project.urls]
 homepage = "https://github.com/pyctrl/izulu"


### PR DESCRIPTION
- Fix factory overload
- Use typing_extensions for dataclass_transform, which allows us to make a annotation for all versions of python.